### PR TITLE
Replacing error logs with warning logs

### DIFF
--- a/scripting/dm_preset_spawns.sp
+++ b/scripting/dm_preset_spawns.sp
@@ -118,8 +118,8 @@ bool:LoadMapConfig()
 	new Handle:file = OpenFile(path, "rt");
 	if (file == INVALID_HANDLE)
 	{
-		LogError("Could not find spawn point file \"%s\"", path);
-		LogError("Defaulting to map-based spawns!");
+		LogMessage("Could not find spawn point file \"%s\"", path);
+		LogMessage("Defaulting to map-based spawns!");
 		return false;
 	}
 	


### PR DESCRIPTION
Replacing error logs with warning logs in order to prevent error_\* logs spam (logs for this type of reasons are mandatory and should not be taken as they were errors).
