### PR TITLE
NPOTB: Update SourceMod dependency to 1.10

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -79,6 +79,7 @@ class CSSDM:
 				self.compiler.AddToListVar('CXXFLAGS', '-Wno-non-virtual-dtor')
 				self.compiler.AddToListVar('CXXFLAGS', '-Wno-overloaded-virtual')
 				self.compiler.AddToListVar('CXXFLAGS', '-Wno-deprecated-register')
+				self.compiler.AddToListVar('CXXFLAGS', '-std=c++11')
 				if (self.vendor == 'gcc' and cxx.majorVersion >= 4 and cxx.minorVersion >= 7) or \
 						(self.vendor == 'clang' and cxx.majorVersion >= 3):
 					self.compiler.AddToListVar('CXXFLAGS', '-Wno-delete-non-virtual-dtor')

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -117,6 +117,7 @@ class CSSDM:
 				self.compiler.AddToListVar('POSTLINKFLAGS', 'uuid.lib')
 				self.compiler.AddToListVar('POSTLINKFLAGS', 'odbc32.lib')
 				self.compiler.AddToListVar('POSTLINKFLAGS', 'odbccp32.lib')
+				self.compiler.AddToListVar('POSTLINKFLAGS', 'legacy_stdio_definitions.lib')
 
 			#Optimization
 			if AMBuild.options.opt == '1':

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -150,7 +150,8 @@ class CSSDM:
 				self.compiler.AddToListVar('POSTLINKFLAGS', '-mmacosx-version-min=10.5')
 				self.compiler.AddToListVar('POSTLINKFLAGS', ['-arch', 'i386'])
 				self.compiler.AddToListVar('POSTLINKFLAGS', '-lstdc++')
-
+				self.compiler.AddToListVar('CXXFLAGS',
+                                        '-Wno-implicit-exception-spec-mismatch')
 				# For OS X dylib versioning
 				import re
 				productFile = open(os.path.join(AMBuild.sourceFolder, 'product.version'), 'r')

--- a/buildbot/bootstrap.pl
+++ b/buildbot/bootstrap.pl
@@ -23,7 +23,7 @@ my $reconf = 0;
 if ($^O eq "linux") {
 	$ENV{'SOURCEMOD110'} = '/home/builds/common/sourcemod-1.10';
 } elsif ($^O eq "darwin") {
-	$ENV{'SOURCEMOD17'} = '/Users/builds/slaves/common/sourcemod-1.7';
+	$ENV{'SOURCEMOD110'} = '/Users/builds/slaves/common/sourcemod-1.10';
 } else {
 	#JUST IN CASE
 	$ENV{'SOURCEMOD110'} = 'D:\\scripts\\common\\sourcemod-1.10';

--- a/buildbot/bootstrap.pl
+++ b/buildbot/bootstrap.pl
@@ -26,7 +26,7 @@ if ($^O eq "linux") {
 	$ENV{'SOURCEMOD17'} = '/Users/builds/slaves/common/sourcemod-1.7';
 } else {
 	#JUST IN CASE
-	$ENV{'SOURCEMOD110'} = 'C:\\scripts\\common\\sourcemod-1.10';
+	$ENV{'SOURCEMOD110'} = 'D:\\scripts\\common\\sourcemod-1.10';
 	#$ENV{'MMSOURCE19'} = "C:\\Scripts\\common\\mmsource-1.9";
 	#$ENV{'HL2SDKCSGO'} = "C:\\Scripts\\common\\hl2sdk-csgo";
 }

--- a/buildbot/bootstrap.pl
+++ b/buildbot/bootstrap.pl
@@ -26,7 +26,7 @@ if ($^O eq "linux") {
 	$ENV{'SOURCEMOD17'} = '/Users/builds/slaves/common/sourcemod-1.7';
 } else {
 	#JUST IN CASE
-	$ENV{'SOURCEMOD110'} = 'D:\\scripts\\common\\sourcemod-1.10';
+	$ENV{'SOURCEMOD110'} = 'C:\\scripts\\common\\sourcemod-1.10';
 	#$ENV{'MMSOURCE19'} = "C:\\Scripts\\common\\mmsource-1.9";
 	#$ENV{'HL2SDKCSGO'} = "C:\\Scripts\\common\\hl2sdk-csgo";
 }


### PR DESCRIPTION
A bit of a headache, but successful in the end.

This patch was a pretty delicate balancing act between the build slaves and the project build configs, but all should be well. 