### PR TITLE
Update CS:S FFA TakeDmgPatch1 offset + patch

### DIFF
--- a/gamedata/cssdm.games.txt
+++ b/gamedata/cssdm.games.txt
@@ -145,7 +145,7 @@
 			"LagCompPatch_Mac"		"\x90\x90\x90\x90\x90\x90"
 			
 			"TakeDmgPatch1_Windows"		"\xEB"
-			"TakeDmgPatch1_Linux"		"\x90\x90\x90\x90\x90\x90"
+			"TakeDmgPatch1_Linux"		"\x84"
 			"TakeDmgPatch1_Mac"		"\x90\x90\x90\x90\x90\x90"
 			
 			"TakeDmgPatch2_Windows"		"\xEB"
@@ -168,7 +168,7 @@
 			"TakeDmgPatch1"
 			{
 				"windows"		"828"
-				"linux"			"564"
+				"linux"			"760"
 				"mac"			"746"
 			}
 			"TakeDmgPatch2"


### PR DESCRIPTION
The logic of CCSPlayer::OnTakeDamage for Linux changed.

Previously at offset 564 there was:
`CCSPlayer::OnTakeDamage(CTakeDamageInfo const&)+234  0F 84 E6 FE FF FF                       jz      loc_594720`

Not only did the offset change, also the `jz` changed to `jnz`:
`CCSPlayer::OnTakeDamage(CTakeDamageInfo const&)+2F7  0F 85 EB 00 00 00                       jnz     loc_591B48`

By patching `0x85` (`jz`) to `0x84` (`jnz`) at offset `760` FFA is working again as expected.