### PR TITLE
Update gamedata after 2025/02 update

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -157,7 +157,7 @@ class CSSDM:
 				productFile = open(os.path.join(AMBuild.sourceFolder, 'product.version'), 'r')
 				productContents = productFile.read()
 				productFile.close()
-				m = re.match('(\d+)\.(\d+)\.(\d+).*', productContents)
+				m = re.match(r'(\d+)\.(\d+)\.(\d+).*', productContents)
 				if m == None:
 					self.version = '1.0.0'
 				else:

--- a/cssdm_ffa.cpp
+++ b/cssdm_ffa.cpp
@@ -151,7 +151,7 @@ bool DM_Prepare_FFA(char *error, size_t maxlength)
 	if (!g_pDmConf->GetOffset("TakeDmgPatch2", &g_takedmg_offset[1])
 		|| !g_takedmg_offset[1])
 	{
-		snprintf(error, maxlength, "Could not find TakeDmgPatch1 offset");
+		snprintf(error, maxlength, "Could not find TakeDmgPatch2 offset");
 		return false;
 	}
 	if (!DM_FFA_LoadPatch("TakeDmgPatch2", &g_takedmg_patch[1], error, maxlength))

--- a/gamedata/cssdm.games.txt
+++ b/gamedata/cssdm.games.txt
@@ -144,7 +144,7 @@
 			"LagCompPatch_Linux"		"\x90\x90\x90\x90\x90\x90"
 			
 			"TakeDmgPatch1_Windows"		"\xEB"
-			"TakeDmgPatch1_Linux"		"\x74"
+			"TakeDmgPatch1_Linux"		"\xEB"
 			
 			"CalcDomRevPatch_Windows"	"\x90\x90\x90\x90\x90\x90"
 			"CalcDomRevPatch_Linux"		"\x90\x90\x90\x90\x90\x90"
@@ -159,7 +159,7 @@
 			}
 			"TakeDmgPatch1"
 			{
-				"windows"		"918"
+				"windows"		"844"
 				"linux"			"504"
 			}
 			/* Offset into gamerules constructor - bogo value linux/mac */

--- a/gamedata/cssdm.games.txt
+++ b/gamedata/cssdm.games.txt
@@ -140,21 +140,14 @@
 		/* FFA patch bytes */
 		"Keys"
 		{
-			"LagCompPatch_Windows"		"\xEB"
+			"LagCompPatch_Windows"		"\x90\x90\x90\x90\x90\x90"
 			"LagCompPatch_Linux"		"\x90\x90\x90\x90\x90\x90"
-			"LagCompPatch_Mac"		"\x90\x90\x90\x90\x90\x90"
 			
 			"TakeDmgPatch1_Windows"		"\xEB"
-			"TakeDmgPatch1_Linux"		"\x84"
-			"TakeDmgPatch1_Mac"		"\x90\x90\x90\x90\x90\x90"
-			
-			"TakeDmgPatch2_Windows"		"\xEB"
-			"TakeDmgPatch2_Linux"		"\x90\x90\x90\x90\x90\x90"
-			"TakeDmgPatch2_Mac"		"\x90\x90\x90\x90\x90\x90"
+			"TakeDmgPatch1_Linux"		"\x74"
 			
 			"CalcDomRevPatch_Windows"	"\x90\x90\x90\x90\x90\x90"
-			"CalcDomRevPatch_Linux"		"\x90\x90"
-			"CalcDomRevPatch_Mac"		"\x90\x90\x90\x90\x90\x90"
+			"CalcDomRevPatch_Linux"		"\x90\x90\x90\x90\x90\x90"
 		}
 		"Offsets"
 		{
@@ -162,71 +155,55 @@
 			"LagCompPatch"
 			{
 				"windows"		"46"
-				"linux"			"31"
-				"mac"			"32"
+				"linux"			"25"
 			}
 			"TakeDmgPatch1"
 			{
-				"windows"		"828"
-				"linux"			"760"
-				"mac"			"746"
-			}
-			"TakeDmgPatch2"
-			{
-				"windows"		"828"
-				"linux"			"564"
-				"mac"			"746"
+				"windows"		"918"
+				"linux"			"504"
 			}
 			/* Offset into gamerules constructor - bogo value linux/mac */
 			"g_pGameRules"
 			{
 				"windows"		"5"
 				"linux"			"1"
-				"mac"			"1"
 			}
 			/* Virtual indexes */
 			"IPointsForKill"
 			{
 				"windows"		"80"
 				"linux"			"81"
-				"mac"			"81"
 			}
 			"Weapon_GetSlot"
 			{
-				"windows"		"268"
-				"linux"			"269"
-				"mac"			"269"
+				"windows"		"274"
+				"linux"			"275"
 			}
 			"RemoveAllItems"
 			{
-				"windows"		"342"
-				"linux"			"343"
-				"mac"			"343"
+				"windows"		"348"
+				"linux"			"349"
 			}
 			"GiveAmmo"
 			{
-				"windows"		"252"
-				"linux"			"253"
-				"mac"			"253"
+				"windows"		"258"
+				"linux"			"259"
 			}
 			/* Next _two_ are detour byte "save" counts */
 			"DropWeaponsPatch"
 			{
 				"windows"		"6"
 				"linux"			"6"
-				"mac"			"6"
 			}
 			"CSWeaponDropPatch"
 			{
 				"windows"		"9"
 				"linux"			"6"
-				"mac"			"6"
 			}
 			"CalcDomRevPatch"
 			{
 				"windows"		"65"
-				"linux"			"96"
-				"mac"			"86"
+				"linux"			"72"
 			}
 		}
 		"Signatures"
@@ -234,58 +211,50 @@
 			"UTIL_Remove"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x56\x57\x8B\x7D\x08\x8B\xF1\x57\xE8\x2A\x2A\x2A\x2A\x8B\x0D\x2A\x2A\x2A\x2A\x57\x56"
+				"windows"		"\x55\x8B\xEC\x56\x8B\x75\x08\x85\xF6\x74\x2A\x83\xC6\x0C"
 				"linux"			"@_Z11UTIL_RemoveP11CBaseEntity"
-				"mac"			"@_Z11UTIL_RemoveP11CBaseEntity"
 			}
 			"RoundRespawn"
 			{
 				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x51\x89\x2A\x2A\x8B\x2A\x2A\x8B\x10\x8B"
+				"windows"	"\x55\x8B\xEC\x51\x89\x4D\xFC\x8B\x45\xFC\x8B\x10"
 				"linux"		"@_ZN9CCSPlayer12RoundRespawnEv"
-				"mac"		"@_ZN9CCSPlayer12RoundRespawnEv"
 			}
 			"OnTakeDamage"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x81\xEC\x2A\x2A\x2A\x2A\x56\x89\x4D\xFC\x8B\x45\x2A\x50\x8D\x8D\x2A\x2A\x2A\x2A\xE8"
+				"windows"		"\x55\x8B\xEC\x81\xEC\x40\x01\x00\x00\x56\x89\x4D\xFC"
 				"linux"			"@_ZN9CCSPlayer12OnTakeDamageERK15CTakeDamageInfo"
-				"mac"			"@_ZN9CCSPlayer12OnTakeDamageERK15CTakeDamageInfo"
 			}
 			"WantsLagComp"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x83\xEC\x10\xA1\x2A\x2A\x2A\x2A\x56\x8B\xF1\x57"
+				"windows"		"\x55\x8B\xEC\x83\xEC\x10\xA1\x2A\x2A\x2A\x2A\x56"
 				"linux"			"@_ZNK11CBasePlayer28WantsLagCompensationOnEntityEPKS_PK8CUserCmdPK7CBitVecILi2048EE"
-				"mac"			"@_ZNK11CBasePlayer28WantsLagCompensationOnEntityEPKS_PK8CUserCmdPK7CBitVecILi2048EE"
 			}
 			"CGameRules"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x8B\x0D\x2A\x2A\x2A\x2A\x85\xC9\x74\x07"
+				"windows"		"\x55\x8B\xEC\x8B\x0D\x2A\x2A\x2A\x2A\x85\xC9\x74\x2A\x8B\x01\x6A\x01"
 				"linux"			"@g_pGameRules"
-				"mac"			"@g_pGameRules"
 			}
 			"CSWeaponDrop"
 			{
 				"library"		"server"
-				"windows"		"\x2A\x2A\x2A\x2A\x2A\x2A\x01\x00\x00\x89\x4D\xFC\xC6\x45\x2A\x2A\x8B\x4D\x2A\xE8\x2A\x2A\x2A\x2A\x0F\xB6\xC0"
+				"windows"		"\x55\x8B\xEC\x81\xEC\x80\x01\x00\x00\x89\x4D\xFC"
 				"linux"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeaponbb"
-				"mac"			"@_ZN9CCSPlayer12CSWeaponDropEP17CBaseCombatWeaponbb"
 			}
 			"DropWeapons"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x83\xEC\x2A\x89\x4D\x2A\xC7\x45\x2A\x00\x00\x00\x00\xEB\x2A\x8B\x45\x2A\x83\xC0\x01\x89\x45\x2A\x83"
+				"windows"		"\x55\x8B\xEC\x83\xEC\x58\x89\x4D\xF8"
 				"linux"			"@_ZN9CCSPlayer11DropWeaponsEbb"
-				"mac"			"@_ZN9CCSPlayer11DropWeaponsEbb"
 			}
 			"CalcDominationAndRevenge"
 			{
 				"library"		"server"
-				"windows"		"\x55\x8B\xEC\x51\xA1\x2A\x2A\x2A\x2A\x89\x4D\xFC\x83\x78\x30\x00\x0F\x85\x2A\x2A\x2A\x2A\x57\x8B"
+				"windows"		"\x55\x8B\xEC\x51\xA1\x2A\x2A\x2A\x2A\x89\x4D\xFC"
 				"linux"			"@_ZN12CCSGameStats24CalcDominationAndRevengeEP9CCSPlayerS1_Pi"
-				"mac"			"@_ZN12CCSGameStats24CalcDominationAndRevengeEP9CCSPlayerS1_Pi"
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #20

This has been sitting in my GitHub for a long time, finally got around to finishing it. Also the build script will need tweaking as I tried building it today but it won't build out of the box with all the SDK changes. I tested it with the latest build of CSSDM and the latest version of SM/MM:S, everything seems to be working.

Below is a summary on what got changed

---

#### ```TakeDmgPatch1```

On Linux, the relevant section got changed to (in IDA)
```asm
.text:00710940 loc_710940:                             ; CODE XREF: CCSPlayer::OnTakeDamage(CTakeDamageInfo const&)+146↑j
.text:00710940                                         ; CCSPlayer::OnTakeDamage(CTakeDamageInfo const&)+160↑j ...
.text:00710940                 mov     eax, edi
.text:00710942                 test    al, al
.text:00710944                 jnz     loc_710FF0
.text:0071094A                 mov     edi, [ebp+lpsrc]
.text:00710950                 sub     esp, 0Ch
.text:00710953                 push    edi             ; this
.text:00710954                 call    _ZNK11CBaseEntity13GetTeamNumberEv ; CBaseEntity::GetTeamNumber(void)
.text:00710959                 mov     [esp], ebx      ; this
.text:0071095C                 mov     esi, eax
.text:0071095E                 call    _ZNK11CBaseEntity13GetTeamNumberEv ; CBaseEntity::GetTeamNumber(void)
.text:00710963                 add     esp, 10h
.text:00710966                 cmp     esi, eax
.text:00710968                 jnz     short loc_710978
.text:0071096A                 cmp     edi, ebx
.text:0071096C                 jnz     loc_710B20
.text:00710972                 lea     esi, [esi+0]
```
I simply changed `jnz short loc_710978` at `00710968` to a `jmp` and it works just fine

On Windows this got changed to
```asm
.text:10295690 loc_10295690:                           ; CODE XREF: CCSPlayer__OnTakeDamage+1C3↑j
.text:10295690                                         ; CCSPlayer__OnTakeDamage+1DD↑j ...
.text:10295690                 movzx   ecx, [ebp+var_5]
.text:10295694                 test    ecx, ecx
.text:10295696                 jnz     short loc_102956CA
.text:10295698                 mov     ecx, [ebp+var_14]
.text:1029569B                 call    sub_100F8340
.text:102956A0                 mov     esi, eax
.text:102956A2                 mov     ecx, [ebp+var_4]
.text:102956A5                 call    sub_100F8340
.text:102956AA                 cmp     esi, eax
.text:102956AC                 jnz     short loc_102956CA
.text:102956AE                 mov     edx, [ebp+var_14]
.text:102956B1                 cmp     edx, [ebp+var_4]
.text:102956B4                 jz      short loc_102956CA
.text:102956B6                 lea     ecx, [ebp+var_100]
.text:102956BC                 call    sub_1005B670
.text:102956C1                 cmp     eax, [ebp+var_4]
.text:102956C4                 jnz     loc_10295EA2
```
I did a lot of trial and error and eventually patching out the `jnz` to a `jmp` at `102956AC` did the trick (in hindsight `sub_100F8340` would've been `CBaseEntity::GetTeamNumber`)

`CalcDomRevPatch` and `LagCompPatch` are pretty straight forward as it simply skips the jump on friendly fire. `CalcDomRevPatch` works but I am unable to test `LagCompPatch` properly.

I used [asherkin's VTable dumper](https://asherkin.github.io/vtable/) for the offsets, and [`makesig7.idc`](https://github.com/alliedmodders/sourcemod/blob/master/tools/ida_scripts/makesig7.idc) for the Windows signatures. The signatures were done long ago and I can't remember the details on how I did them.